### PR TITLE
Fix missing imageCropperViewDidChangeCropRect event

### DIFF
--- a/AKImageCropperView/AKImageCropperView.swift
+++ b/AKImageCropperView/AKImageCropperView.swift
@@ -40,7 +40,7 @@ open class AKImageCropperView: UIView, UIScrollViewDelegate, UIGestureRecognizer
     fileprivate var reversedRect: CGRect {
         return CGRect(
             origin  : .zero,
-            size    : ((angle / M_PI_2).truncatingRemainder(dividingBy: 2)) == 1
+            size    : ((angle / (Double.pi / 2)).truncatingRemainder(dividingBy: 2)) == 1
                 ? CGSize(width: frame.size.height, height: frame.size.width)
                 : frame.size)
     }
@@ -52,19 +52,19 @@ open class AKImageCropperView: UIView, UIScrollViewDelegate, UIGestureRecognizer
         var newEdgeInsets: UIEdgeInsets
         
         switch angle {
-        case M_PI_2:
+        case (Double.pi / 2):
             newEdgeInsets = UIEdgeInsetsMake(
                 minEdgeInsets.right,
                 minEdgeInsets.top,
                 minEdgeInsets.left,
                 minEdgeInsets.bottom)
-        case M_PI:
+        case Double.pi:
             newEdgeInsets = UIEdgeInsetsMake(
                 minEdgeInsets.bottom,
                 minEdgeInsets.right,
                 minEdgeInsets.top,
                 minEdgeInsets.left)
-        case M_PI_2 * 3:
+        case (Double.pi / 2) * 3:
             newEdgeInsets = UIEdgeInsetsMake(
                 minEdgeInsets.left,
                 minEdgeInsets.bottom,
@@ -563,7 +563,7 @@ open class AKImageCropperView: UIView, UIScrollViewDelegate, UIGestureRecognizer
     
     open func rotate(_ angle: Double, withDuration duration: TimeInterval = 0, options: UIViewAnimationOptions = .curveEaseInOut, completion: ((Bool) -> Void)? = nil) {
         
-        guard angle.truncatingRemainder(dividingBy: M_PI_2) == 0 else {
+        guard angle.truncatingRemainder(dividingBy: (Double.pi / 2)) == 0 else {
             return
         }
         

--- a/AKImageCropperView/AKImageCropperView.swift
+++ b/AKImageCropperView/AKImageCropperView.swift
@@ -746,6 +746,8 @@ open class AKImageCropperView: UIView, UIScrollViewDelegate, UIGestureRecognizer
             scrollView.minimumZoomScale *= fillScaleMultiplier
             scrollView.zoomScale        *= fillScaleMultiplier
         }
+
+        delegate?.imageCropperViewDidChangeCropRect(view: self, cropRect: scrollView.scaledVisibleRect)
     }
     
     // MARK: - UIScrollViewDelegate


### PR DESCRIPTION
Call `imageCropperViewDidChangeCropRect` when crop rect is changed
And clean Xcode build warnings